### PR TITLE
Add Hyperliquid deployment script and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,26 +25,61 @@ cd ts-template
 
 ### 2. Install Dependencies
 
-Make sure you have pnpm installed. Then, run:
+Make sure you have [Yarn](https://yarnpkg.com/) installed (this project is configured for Yarn Berry). Then, run:
 
 ```bash
-pnpm install
+yarn install
 ```
 
-### 3. Start Developing
+### 3. Configure Hyperliquid Credentials
+
+Copy the example environment file and provide your Hyperliquid testnet details:
+
+```bash
+cp .env.example .env
+```
+
+Set the following variables in `.env`:
+
+- `HYPERLIQUID_PRIVATE_KEY` – Vault signer private key as a 0x-prefixed 64 character hex string.
+- `HYPERLIQUID_TESTNET_RPC_URL` – HTTP RPC endpoint for the Hyperliquid testnet.
+- `HYPERLIQUID_TESTNET_WS_URL` – WebSocket endpoint for the Hyperliquid testnet.
+- `HYPERLIQUID_VAULT_ADDRESS` – Vault contract address you plan to publish.
+
+The CLI validates these values on start-up and exits with a helpful error message if anything is missing or malformed.
+
+### 4. Run the Hyperliquid deployment script
+
+With your environment configured, trigger a deployment attempt against the Hyperliquid testnet:
+
+```bash
+yarn deploy:hyperliquid
+```
+
+Expected logs include the vault being targeted, the client method signature that succeeded, and any response returned by the SDK:
+
+```text
+Preparing Hyperliquid deployment for vault 0xabc123...
+Hyperliquid deployment succeeded using deploy(payload, signer).
+Hyperliquid response: { "txHash": "0x..." }
+```
+
+If deployment fails you will see `Hyperliquid deployment failed:` followed by detailed method attempts, and the command exits with status code `1`.
+
+### 5. Start Developing
 
 Kickstart your development with autoreload on save:
 
 ```bash
-pnpm dev
+yarn dev
 ```
 
-### 4. Build for Production
+### 6. Build for Production
 
 Ready to ship? Build your project with:
 
 ```bash
-pnpm build
+yarn build
 ```
 
 ### Project Structure 📁
@@ -67,6 +102,7 @@ ts-template/
 ### Scripts 📝
 
 * **yarn dev:** Run your project with autoreload.
+* **yarn deploy:hyperliquid:** Load `.env`, validate your Hyperliquid credentials, and attempt a testnet deployment using the SDK. Successful runs log the method used and response payload; failures print detailed rejection reasons and exit with code `1`.
 * **yarn start:** Run your build.
 * **yarn lint:** Lint your TypeScript code using ESLint.
 * **yarn lint:fix:** Lint and fix your TypeScript code using ESLint.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "dev": "dotenv -e .env -- ts-node-dev --transpile-only ./src/index.ts",
+    "deploy:hyperliquid": "dotenv -e .env -- ts-node-dev --transpile-only --exit-child ./src/index.ts deploy:hyperliquid",
     "build": "tsup --config build.ts",
     "start": "dotenv -e .env -- node ./dist/index.js",
     "lint": "eslint",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,43 @@
 import { hyperliquidConfig } from "./config/hyperliquid"
+import { deploy as deployHyperliquid } from "./hyperliquid/deploy"
 
-function main() {
-    console.log(`Hyperliquid configuration loaded for vault ${hyperliquidConfig.vaultAddress}.`)
+type CommandHandler = () => Promise<number | void>
+
+const COMMAND_HANDLERS: Record<string, CommandHandler> = {
+    "deploy:hyperliquid": deployHyperliquid,
+    "deploy-hyperliquid": deployHyperliquid,
 }
 
-main()
+const DEFAULT_COMMAND_MESSAGE = `Hyperliquid configuration loaded for vault ${hyperliquidConfig.vaultAddress}.`
+
+async function main(): Promise<void> {
+    const [, , rawCommand] = process.argv
+
+    if (!rawCommand) {
+        console.log(DEFAULT_COMMAND_MESSAGE)
+        return
+    }
+
+    const normalizedCommand = rawCommand.toLowerCase()
+    const handler = COMMAND_HANDLERS[normalizedCommand]
+
+    if (!handler) {
+        console.error(`Unknown command: ${rawCommand}`)
+        console.error("Available commands: deploy:hyperliquid")
+        process.exitCode = 1
+        return
+    }
+
+    try {
+        const exitCode = await handler()
+        if (typeof exitCode === "number") {
+            process.exit(exitCode)
+        }
+    } catch (error) {
+        console.error(`Command ${rawCommand} failed with an unexpected error:`)
+        console.error(error)
+        process.exit(1)
+    }
+}
+
+void main()


### PR DESCRIPTION
## Summary
- add a `yarn deploy:hyperliquid` script that wires into the existing dotenv wrapper
- update the TypeScript CLI entrypoint to invoke the Hyperliquid deployment helper when the command is used
- document how to configure Hyperliquid credentials and interpret the deploy command output

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cff6eebb3883248b0b84e6576752a1