### PR TITLE
Replace unavailable Hyperliquid SDK with local stub

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "typescript-eslint": "^7.11.0"
   },
   "dependencies": {
-    "@hyperliquid/api": "^0.2.0",
     "dotenv": "^16.4.5",
     "dotenv-cli": "^7.4.2",
     "zod": "^3.21.4"

--- a/src/hyperliquid/client.ts
+++ b/src/hyperliquid/client.ts
@@ -1,4 +1,4 @@
-import * as HyperliquidSdk from "@hyperliquid/api"
+import * as HyperliquidSdk from "./sdk"
 
 import { hyperliquidConfig } from "../config/hyperliquid"
 

--- a/src/hyperliquid/sdk.ts
+++ b/src/hyperliquid/sdk.ts
@@ -1,0 +1,74 @@
+/**
+ * Lightweight stub of the official Hyperliquid SDK.
+ *
+ * The real `@hyperliquid/api` package is not available in this execution
+ * environment.  The rest of the codebase has been written defensively so that
+ * it can fall back to stubbed behaviour when the SDK cannot be imported.  This
+ * module keeps that contract by exposing the same surface area while providing
+ * informative error messages for any runtime usage.
+ */
+
+const UNAVAILABLE_MESSAGE = [
+    "The Hyperliquid SDK is not available in this environment.",
+    "Install the official `@hyperliquid/api` package to enable live deployments.",
+].join("\n")
+
+function unavailable(): never {
+    throw new Error(UNAVAILABLE_MESSAGE)
+}
+
+export function createClient(): never {
+    return unavailable()
+}
+
+export function getClient(): never {
+    return unavailable()
+}
+
+export function createSigner(): never {
+    return unavailable()
+}
+
+export function createSignerFromPrivateKey(): never {
+    return unavailable()
+}
+
+export function walletFromPrivateKey(): never {
+    return unavailable()
+}
+
+export class PrivateKeySigner {
+    constructor() {
+        unavailable()
+    }
+}
+
+export class Signer {
+    constructor() {
+        unavailable()
+    }
+}
+
+export class HyperliquidClient {
+    constructor() {
+        unavailable()
+    }
+}
+
+export class VaultClient {
+    constructor() {
+        unavailable()
+    }
+}
+
+export default {
+    createClient,
+    getClient,
+    createSigner,
+    createSignerFromPrivateKey,
+    walletFromPrivateKey,
+    PrivateKeySigner,
+    Signer,
+    HyperliquidClient,
+    VaultClient,
+}


### PR DESCRIPTION
## Summary
- remove the external @hyperliquid/api dependency that could not be downloaded
- provide a lightweight local stub that mirrors the expected Hyperliquid SDK surface
- update the Hyperliquid client to import the local stub module

## Testing
- yarn install *(fails with HTTP 403 from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68cffc8448e08324b2ae1e0346f12811