### PR TITLE
Configure project for Vercel deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,15 @@ Ready to ship? Build your project with:
 yarn build
 ```
 
+### 7. Deploying to Vercel
+
+This repository is configured for Vercel deployments out of the box:
+
+- `vercel.json` pins the runtime to **Node.js 20**, runs `yarn install --frozen-lockfile` during installs, and builds the CLI with `yarn build`.
+- A serverless function at `api/deploy.ts` exposes the existing Hyperliquid deployment flow over HTTP. Trigger a deployment by issuing a `POST` request to `/api/deploy`.
+
+Before deploying, add the required `HYPERLIQUID_*` environment variables to your Vercel project. A successful request returns JSON describing the invoked SDK method and payload. Non-`POST` requests receive a `405 Method Not Allowed` response that points to the supported method.
+
 ### Project Structure 📁
 
 ```bash

--- a/api/deploy.ts
+++ b/api/deploy.ts
@@ -1,0 +1,60 @@
+import { performHyperliquidDeployment } from "../src/hyperliquid/deploy"
+
+const ALLOWED_METHOD = "POST" as const
+
+type AllowedMethod = typeof ALLOWED_METHOD
+
+type DeployRequest = {
+    method?: string
+}
+
+type DeployResponse = {
+    status: (statusCode: number) => DeployResponse
+    json: (body: unknown) => DeployResponse
+    setHeader: (name: string, value: string | readonly string[]) => void
+}
+
+function methodNotAllowedResponse(response: DeployResponse, method: string | undefined): DeployResponse {
+    response.setHeader("Allow", ALLOWED_METHOD)
+    const description = method ? `${method.toUpperCase()} is not supported.` : "An HTTP method is required."
+
+    return response.status(405).json({
+        ok: false,
+        error: "Method Not Allowed",
+        details: [
+            description,
+            `Use ${ALLOWED_METHOD} to trigger a Hyperliquid deployment.`,
+        ],
+    })
+}
+
+export default async function handler(request: DeployRequest, response: DeployResponse): Promise<void> {
+    const method = request.method?.toUpperCase() as AllowedMethod | undefined
+
+    if (method !== ALLOWED_METHOD) {
+        methodNotAllowedResponse(response, request.method)
+        return
+    }
+
+    try {
+        const result = await performHyperliquidDeployment()
+
+        response.status(200).json({
+            ok: true,
+            methodSignature: result.methodSignature,
+            payload: result.payload,
+            response: result.response,
+        })
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        const [headline, ...rest] = message.split("\n").map(part => part.trim()).filter(Boolean)
+
+        console.error("Hyperliquid deployment failed while serving /api/deploy:", error)
+
+        response.status(500).json({
+            ok: false,
+            error: headline ?? "Deployment failed with an unknown error.",
+            details: rest.length > 0 ? rest : undefined,
+        })
+    }
+}

--- a/src/hyperliquid/deploy.ts
+++ b/src/hyperliquid/deploy.ts
@@ -19,7 +19,7 @@ export interface VaultDeploymentPayload {
     }>
 }
 
-interface DeploymentSuccess {
+export interface DeploymentSuccess {
     methodSignature: string
     response: unknown
 }
@@ -43,6 +43,10 @@ type ClientRecord = Record<string, unknown>
 type DeploymentTarget = {
     target: ClientRecord | undefined
     method: string
+}
+
+export interface DeploymentResult extends DeploymentSuccess {
+    payload: VaultDeploymentPayload
 }
 
 const clientRecord = hyperliquidClient as ClientRecord
@@ -200,13 +204,22 @@ async function sendDeployment(payload: VaultDeploymentPayload): Promise<Deployme
     )
 }
 
+export async function performHyperliquidDeployment(): Promise<DeploymentResult> {
+    const payload = buildDeploymentPayload()
+    const { methodSignature, response } = await sendDeployment(payload)
+
+    return {
+        payload,
+        methodSignature,
+        response,
+    }
+}
+
 export async function deploy(): Promise<number> {
     console.info(`Preparing Hyperliquid deployment for vault ${hyperliquidConfig.vaultAddress}...`)
 
-    const payload = buildDeploymentPayload()
-
     try {
-        const { methodSignature, response } = await sendDeployment(payload)
+        const { methodSignature, response } = await performHyperliquidDeployment()
 
         console.info(`Hyperliquid deployment succeeded using ${methodSignature}.`)
         const formattedResponse = formatForLog(response)

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,10 @@
+{
+  "version": 2,
+  "functions": {
+    "api/*.ts": {
+      "runtime": "nodejs20.x"
+    }
+  },
+  "installCommand": "yarn install --frozen-lockfile",
+  "buildCommand": "yarn build"
+}


### PR DESCRIPTION
## Summary
- add a Vercel serverless function that exposes the Hyperliquid deploy flow over POST /api/deploy
- refactor the deploy helper to share logic between the CLI and the Vercel entrypoint
- document the Vercel setup and add vercel.json to pin the runtime and build commands

## Testing
- yarn install --frozen-lockfile *(fails: registry responded with HTTP 403)*
- yarn lint *(fails: workspace not installed because yarn install was unable to run)*

------
https://chatgpt.com/codex/tasks/task_e_68d014b67f848324bcdc6f7b24225ea7